### PR TITLE
docs: add dependencies for pylibssh

### DIFF
--- a/docs/running-tests.rst
+++ b/docs/running-tests.rst
@@ -12,7 +12,7 @@ virtual environment.
 .. code-block:: text
 
     # Install python-ldap dependencies
-    sudo dnf install -y gcc python3-devel openldap-devel
+    sudo dnf install -y gcc python3-devel openldap-devel libssh libssh-devel
 
     # Install test dependencies
     python3 -m venv .venv


### PR DESCRIPTION
During the installation it was missing libssh and libssh-devel dependencies for pylibssh

Resolves: https://github.com/SSSD/sssd-test-framework/issues/155